### PR TITLE
Upgrade proc-macro-crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ A macro to support `#[cfg()]` on visibility.
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "1.3.0"
+proc-macro-crate = "2.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.0"
 edition = "2021"
 authors = ["TOETOE55 <584605539@qq.com>"]
 readme = "README.md"
+rust-version = "1.66.0"
 license = "MIT"
 keywords = ["macro", "cfg"]
 repository = "https://github.com/TOETOE55/cfg-vis"


### PR DESCRIPTION
You didn't declare an MSRV, so publishing a new version with this in as a patch release should be fine.

cc https://github.com/bkchr/proc-macro-crate/pull/39